### PR TITLE
docs(readme): fix references to upstream project

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 > - **Contemporary development practices**: including LLM-assisted workflows and tooling that support faster iteration.
 > - **Enterprise-ready Workforce IAM**: extending the platform toward the requirements of larger production deployments.
 > 
-> This fork reflects a different roadmap, not a lack of appreciation for upstream. We are grateful to the original maintainers for building and sustaining Kubidm, and this work would not exist without that foundation.
+> This fork reflects a different roadmap, not a lack of appreciation for upstream. We are grateful to the original maintainers for building and sustaining Kanidm, and this work would not exist without that foundation.
 > 
-> If you are using this fork, please report bugs, request features, and seek support through this repository and its associated community channels. As our implementation and priorities differ from upstream, fork-specific issues are best handled here rather than in the upstream Kubidm project. We aim to respond to feedback as quickly as possible and to keep our release cycle fast so fixes and improvements can reach users sooner.
+> If you are using this fork, please report bugs, request features, and seek support through this repository and its associated community channels. As our implementation and priorities differ from upstream, fork-specific issues are best handled here rather than in the upstream Kanidm project. We aim to respond to feedback as quickly as possible and to keep our release cycle fast so fixes and improvements can reach users sooner.
 > 
-> **Special thanks to** [@firstyear](https://github.com/firstyear) and [@yaleman](https://github.com/yaleman) for creating and maintaining Kubidm.
+> **Special thanks to** [@firstyear](https://github.com/firstyear) and [@yaleman](https://github.com/yaleman) for creating and maintaining Kanidm.
 
 ![Kubidm Logo](artwork/logo-small.png)
 


### PR DESCRIPTION
# Change summary

- fix references to upstream project

Fixes pando85/kubidm#390 

Checklist

- [x] book chapter included (not relevant)
- [x] design document included (not relevant)
