### PR TITLE
docs: establish external orchestration as project architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # Kubidm - Simple and Secure Identity Management
 
 > **This repository is an independent fork of [Kanidm](https://github.com/kanidm/kanidm).**
-> 
+>
 > We started this fork because our product direction and development priorities have diverged from the upstream project.
-> 
+>
 > Our focus is on:
-> 
-> - **Cloud-native and Kubernetes-friendly operations**: including modern deployment patterns, object-store backups, and tighter Kubernetes integration.
-> - **Contemporary development practices**: including LLM-assisted workflows and tooling that support faster iteration.
+>
+> - **Modern distributed operations**: machine-readable, idempotent lifecycle, replication, recovery, and maintenance primitives designed for external reconciliation rather than human-only runbooks.
+> - **Cloud-native and Kubernetes-friendly operations**: including modern deployment patterns, object-store backups, health and capability interfaces, and tighter Kubernetes integration.
 > - **Enterprise-ready Workforce IAM**: extending the platform toward the requirements of larger production deployments.
-> 
+>
+> We also embrace contemporary development practices, including LLM-assisted workflows and tooling that support faster iteration. These are development methods rather than a runtime requirement or product architecture dependency.
+>
 > This fork reflects a different roadmap, not a lack of appreciation for upstream. We are grateful to the original maintainers for building and sustaining Kanidm, and this work would not exist without that foundation.
-> 
+>
 > If you are using this fork, please report bugs, request features, and seek support through this repository and its associated community channels. As our implementation and priorities differ from upstream, fork-specific issues are best handled here rather than in the upstream Kanidm project. We aim to respond to feedback as quickly as possible and to keep our release cycle fast so fixes and improvements can reach users sooner.
-> 
+>
 > **Special thanks to** [@firstyear](https://github.com/firstyear) and [@yaleman](https://github.com/yaleman) for creating and maintaining Kanidm.
 
 ![Kubidm Logo](artwork/logo-small.png)
@@ -27,10 +29,31 @@ The goal of this project is to be a complete identity provider, covering the bro
 integrations. You should not need any other components (like Keycloak) when you use Kubidm - we already have everything
 you need!
 
-To achieve this we rely heavily on strict defaults, simple configuration, and self-healing components. This allows
-Kubidm to support small home labs, families, small businesses, and all the way to the largest enterprise needs.
+To achieve this we rely heavily on strict defaults, simple configuration, safe recovery semantics, and
+automation-friendly operational interfaces. This allows Kubidm to support small home labs, families, small businesses,
+and all the way to the largest enterprise needs.
 
 If you want to host your own authentication service, then Kubidm is for you!
+
+## Operational Direction
+
+Kubidm separates distributed-system correctness from infrastructure orchestration.
+
+**Kubidm owns identity, database, replication, recovery, and maintenance semantics. External control planes own desired
+topology, placement, workload lifecycle, rollout sequencing, and reconciliation.**
+
+The project therefore prefers small, explicit, machine-oriented operational primitives over embedding a second generic
+cluster orchestration system into the identity server. Controllers should be able to observe and request safe Kubidm
+state transitions without parsing logs, depending on CLI formatting, sleeping for assumed convergence intervals, or
+reimplementing replication logic.
+
+Kubernetes is a primary orchestration environment for Kubidm, but it is not a runtime dependency of `kubidmd`. Simple
+deployments can continue to use systemd or containers directly, while distributed automation can compose the same
+server-side semantic primitives from Kubernetes operators or other reconcilers.
+
+See the [Operational Model](book/src/operational_model.md) for the user-facing model and the
+[Orchestration Boundary](book/src/developers/designs/orchestration_boundary.md) design decision for the detailed
+responsibility split.
 
 <details>
   <summary>Supported Features</summary>

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -3,6 +3,7 @@
 # Kubidm
 
 - [Introduction to Kubidm](introduction_to_kubidm.md)
+- [Operational Model](operational_model.md)
 
 - [Evaluation Quickstart](evaluation_quickstart.md)
 
@@ -90,12 +91,15 @@
   - [Cryptography Key Domains (2024)](developers/designs/cryptography_key_domains.md)
   - [Domain Join - Machine Accounts](developers/designs/domain_join_machine_accounts.md)
   - [Elevated Priv Mode](developers/designs/elevated_priv_mode.md)
+  - [Node Drain, Replication Fences, and Maintenance Control Plane](developers/designs/node_drain_replication_fences_maintenance.md)
   - [OAuth2 Device Flow](developers/designs/oauth2_device_flow.md)
   - [OAuth2 Refresh Tokens](developers/designs/oauth2_refresh_tokens.md)
-  - [Replication Coordinator](developers/designs/replication_coordinator.md)
+  - [Orchestration Boundary](developers/designs/orchestration_boundary.md)
   - [Replication Design and Notes](developers/designs/replication_design_and_notes.md)
   - [REST Interface](developers/designs/rest_interface.md)
   - [Unixd Multi Resolver 2024](developers/designs/unixd_multi_resolver_2024.md)
+- [Historical / Superseded Designs]()
+  - [Replication Coordinator](developers/designs/replication_coordinator.md)
 - [Python Module](developers/python_module.md)
 - [RADIUS Module Development](developers/radius.md)
 - [Release Checklist](developers/release_checklist.md)

--- a/book/src/developers/designs/orchestration_boundary.md
+++ b/book/src/developers/designs/orchestration_boundary.md
@@ -1,0 +1,252 @@
+# Orchestration Boundary
+
+Status: **Accepted**
+
+Related:
+
+- [Node Drain, Replication Fences, and Maintenance Control Plane](node_drain_replication_fences_maintenance.md)
+- [Replication Coordinator](replication_coordinator.md) — superseded by this decision
+
+## Context
+
+Kubidm is both an identity system and a distributed stateful service. The server must enforce strong
+application-specific invariants around authentication, authorization, persistence, replication,
+recovery, and maintenance. Operating a replicated service also requires a different class of
+concerns: placement, desired replica count, workload replacement, failure-domain policy, rollout
+ordering, storage lifecycle, and continuous reconciliation toward an intended topology.
+
+Those two classes of responsibility are related, but they are not the same problem.
+
+Historically, the inherited Replication Coordinator design proposed embedding additional
+cluster-level coordination into the identity service so that replicas could register, discover
+membership, receive topology, rotate replication configuration, and be garbage-collected by a
+Kubidm-managed coordinator. That design attempted to improve automation, but it also moved generic
+orchestration policy and lifecycle state into the application.
+
+Kubidm has since developed a different operational direction. Replication-aware readiness,
+replication generations, node drain, replication fences, synchronisation barriers, and in-process
+maintenance all expose or enforce **Kubidm-specific correctness semantics** while allowing an
+external controller to decide how a cluster-level workflow should proceed.
+
+This document makes that separation an explicit project architecture principle.
+
+## Decision
+
+**Kubidm is a distributed identity system, not a general-purpose infrastructure orchestrator.**
+
+Kubidm owns the mechanisms and invariants required to manipulate its local and replicated state
+safely. Cluster-level policy and infrastructure lifecycle are delegated to an external
+orchestration layer.
+
+Kubidm will therefore prefer **small, explicit, machine-oriented operational primitives** over an
+embedded cluster-wide controller.
+
+These primitives should allow an external reconciler to observe state and request safe transitions
+without requiring it to understand Kubidm database internals or infer correctness from process
+state, logs, timing, or deployment-environment details.
+
+Kubernetes is a primary orchestration environment for Kubidm, but this decision does not make
+Kubernetes a runtime dependency of `kubidmd`. The same server primitives may be consumed by other
+controllers or automation systems.
+
+## Responsibility Boundary
+
+| Kubidm | External orchestrator |
+| --- | --- |
+| Identity and authorization semantics | Desired replica count and topology policy |
+| Database and on-disk invariants | Workload creation, placement, and replacement |
+| Replication protocol and conflict semantics | Failure-domain and scheduling policy |
+| Replication generations and history validity | Deciding when a recovery workflow should run |
+| Replication fences and fence satisfaction | Selecting peers and sequencing handoff |
+| Refresh/recovery safety rules | Infrastructure-level recovery orchestration |
+| Node drain and write-admission safety | Selecting and ordering nodes for maintenance |
+| In-process database maintenance semantics | Rolling maintenance sequencing |
+| Machine-readable node/data-plane status | Aggregated cluster status and user-facing conditions |
+| Idempotent node-local control operations | Retry, replay, and convergence of the overall workflow |
+
+The boundary is semantic rather than transport-specific. A primitive may be exposed through a Unix
+socket, HTTP, a dedicated mTLS listener, or another versioned protocol. What matters is that the
+server remains authoritative for the correctness condition represented by the operation.
+
+## Principles
+
+### 1. Correctness stays with the component that can prove it
+
+An external controller should not need to reproduce Kubidm's replication algorithm in order to
+operate Kubidm safely.
+
+For example, a controller may need to know whether replica A contains all history known to replica
+B before taking B out of service. The correct interface is not a timestamp, a sleep, a Pod-ready
+condition, or an approximation of the replication update vector in controller code. Kubidm should
+provide a semantic operation such as a replication fence and fence-satisfaction check.
+
+The same rule applies to recovery generations, database maintenance, and future distributed
+operations.
+
+### 2. Policy stays with the orchestration environment
+
+Kubidm should not decide generic infrastructure questions for which the deployment environment
+already has a control plane.
+
+Examples include:
+
+- which machine or availability zone should run a replica;
+- how many replicas a deployment desires;
+- which replica should be replaced after infrastructure failure;
+- whether a rollout should proceed one node at a time;
+- which storage class or volume implementation should back a replica;
+- which node should be selected first for a maintenance operation.
+
+Kubidm may expose constraints that make a choice safe or unsafe, but it should not own the generic
+scheduler or desired-state database for those decisions.
+
+### 3. Operations are designed for reconcilers, not only humans
+
+Operational interfaces should assume that callers can crash, retry, replay, and observe partial
+progress.
+
+Mutating operations intended for automation should therefore be idempotent, or accept stable
+operation identities that provide idempotent semantics. Status must be machine-readable. Failure
+states must distinguish conditions that are retryable from those that require a new plan or human
+intervention.
+
+Human-oriented CLI commands may remain useful frontends, but an external controller should not have
+to parse CLI text or logs to determine correctness.
+
+### 4. Fail closed when safety cannot be established
+
+Distributed operations should not silently weaken their invariants for automation convenience.
+
+If Kubidm cannot prove that a replication fence is satisfied, that a recovery generation is
+compatible, or that a database operation can run exclusively, the operation should fail with
+structured state rather than let the caller infer success from timing or apparent health.
+
+This may reduce availability during an exceptional workflow. That is preferable to presenting an
+unproven state transition as safe.
+
+### 5. Capability discovery precedes assumption
+
+Operational APIs evolve. Controllers must be able to determine whether a node supports the
+primitive and protocol version required by a workflow.
+
+New operator-facing capabilities should therefore be versioned or otherwise capability-discoverable
+from the beginning. A controller should be able to choose a conservative fallback or refuse an
+operation without depending on the Kubidm release string alone.
+
+### 6. Keep node-local mechanisms composable
+
+Where practical, a server operation should describe one meaningful Kubidm transition rather than a
+complete infrastructure workflow.
+
+For example:
+
+```text
+node B: drain -> fence B
+node A: sync until fence B
+node B: run maintenance
+node A: capture fence A
+node B: sync until fence A
+node B: resume
+```
+
+Kubidm defines the semantics of each transition. The external reconciler selects A and B, persists
+workflow progress, handles retries, and decides what to do next.
+
+This makes the primitives useful in Kubernetes without making them Kubernetes-specific.
+
+## Kubernetes
+
+Kubernetes is particularly well suited to the external-orchestration role because it already
+provides the generic mechanisms required by a distributed workload controller:
+
+- a durable desired-state API;
+- watch/reconcile semantics;
+- leader election and optimistic concurrency;
+- scheduling and failure-domain constraints;
+- StatefulSets and stable workload identities;
+- storage lifecycle through CSI;
+- status, conditions, events, and finalizers;
+- rolling workload replacement;
+- extensibility through Custom Resources and operators.
+
+Kubidm should integrate cleanly with these semantics instead of recreating equivalent generic
+control-plane machinery inside the identity server.
+
+This does **not** mean that a simple Kubidm deployment requires Kubernetes. A single node or a
+manually managed deployment can continue to run as a normal service under systemd, a container
+runtime, or another supervisor. The architectural requirement is that advanced automation be able
+to consume supported Kubidm primitives rather than emulate a human administrator.
+
+## Operator-facing API Direction
+
+The long-term operator-facing surface should expose only the semantic primitives that an external
+controller cannot safely derive itself. Examples include:
+
+- replication health and state;
+- replication generation identity and compatibility;
+- node drain/resume;
+- versioned replication fences and fence satisfaction;
+- explicit synchronisation/refresh requests and outcomes;
+- recovery preconditions and progress;
+- maintenance capabilities, state, and idempotent operations;
+- safe replication membership or peer-management primitives if dynamic membership requires them.
+
+These interfaces should not encode Kubernetes resources, scheduling policy, or deployment-specific
+objects. They should describe Kubidm state transitions in Kubidm terms.
+
+## Relationship to the Replication Coordinator Design
+
+The earlier Replication Coordinator design attempted to solve automation by introducing a
+Kubidm-managed topology coordinator responsible for node registration, membership, topology maps,
+generation tracking, configuration distribution, and inactive-node cleanup.
+
+This ADR supersedes that direction.
+
+The underlying problems identified by that document are valid: manual certificate exchange,
+static peer configuration, difficult node replacement, and administrator-driven topology changes
+are poor interfaces for automated operation. The change is **where those problems are solved**.
+
+Rather than adding a second cluster-level control plane inside Kubidm, the server should expose the
+replication and lifecycle mechanisms required by an external reconciler. The reconciler already owns
+the desired topology and infrastructure lifecycle and can compose those mechanisms into a workflow.
+
+The historical coordinator document is retained because it describes useful requirements and the
+reasoning that led to this boundary, but it is no longer the intended implementation direction.
+
+## Consequences
+
+### Positive
+
+- Kubidm stays focused on identity and distributed-data correctness.
+- Kubernetes operators can use native reconciliation rather than adapting to a parallel coordinator.
+- Non-Kubernetes automation can consume the same semantic primitives.
+- Operational correctness can be tested at the server boundary independently from orchestration
+  policy.
+- Controller failures and retries can be handled through explicit idempotency and status semantics.
+- The project avoids maintaining another generic membership/lifecycle control plane.
+
+### Costs
+
+- Some operations require new server APIs before they can be automated safely.
+- External controllers must understand the documented Kubidm operation state machines.
+- Simple deployments and orchestrated deployments may use different levels of the operational API.
+- Until a required primitive exists, an orchestrator may need a conservative workflow with reduced
+  availability rather than a fully online operation.
+
+These costs are intentional. They keep missing automation capabilities visible instead of hiding
+them behind heuristics or duplicating distributed-system logic outside the server.
+
+## Non-goals
+
+This decision does not:
+
+- require Kubernetes to run Kubidm;
+- make Kubidm stateless;
+- move replication correctness into an operator;
+- require a specific Kubernetes operator implementation;
+- prohibit helper tools for users who manage VMs or bare-metal services directly;
+- prohibit server-side automation that is intrinsically part of maintaining Kubidm's own invariants;
+- claim that every cluster operation can be reduced to a trivial node-local call.
+
+The goal is a clear ownership boundary: **Kubidm provides the distributed-system mechanisms and
+proofs; the deployment control plane provides policy and reconciliation.**

--- a/book/src/developers/designs/replication_coordinator.md
+++ b/book/src/developers/designs/replication_coordinator.md
@@ -1,5 +1,22 @@
 # Replication Coordinator
 
+Status: **Superseded**
+
+> This document is retained as architectural history. Kubidm no longer plans to implement a
+> cluster-wide Replication Coordinator as described below. The current architecture keeps
+> Kubidm-specific correctness and node-local operational mechanisms in the server while delegating
+> cluster policy and reconciliation to an external control plane. See
+> [Orchestration Boundary](orchestration_boundary.md) and the
+> [Operational Model](../../operational_model.md).
+>
+> The problems identified by this design—manual certificate exchange, static topology management,
+> difficult replica lifecycle, and human-driven replication administration—remain relevant. What
+> changed is the chosen control-plane boundary: Kubidm should expose the semantic primitives an
+> external reconciler needs instead of embedding a second generic orchestration layer into the
+> identity server.
+
+## Historical design
+
 Many other IDM systems configure replication on each node of the topology. This means that the administrator is
 responsible for ensuring all nodes are connected properly, and that agreements are bidirectional. As well this requires
 manual work for administrators to configure each node individually, as well as monitoring individually. This adds a

--- a/book/src/introduction_to_kubidm.md
+++ b/book/src/introduction_to_kubidm.md
@@ -7,7 +7,8 @@ The intent of the Kubidm project is to:
 
 - Provide a single source of truth for authorisation and authentication.
 - Make system, network, application and web authentication easy and accessible.
-- Secure and reliable by default, aiming for the highest levels of quality and stability.
+- Be secure and reliable by default, aiming for the highest levels of quality and stability.
+- Be straightforward to automate and reconcile through machine-oriented operational interfaces.
 
 ## Why do I want Kubidm?
 
@@ -59,6 +60,11 @@ be revoked.
 
 Due to this model, and the design of Kubidm to centre the device and to have more per-service credentials, workflows and
 automation are added or designed to reduce human handling.
+
+The same automation-first principle applies to operating Kubidm itself. Kubidm owns identity, database, replication,
+and recovery correctness, while deployment-level policy and reconciliation can be delegated to an external control
+plane. See the [Operational Model](operational_model.md) for how this boundary applies to simple and distributed
+deployments.
 
 ## For Developers
 

--- a/book/src/operational_model.md
+++ b/book/src/operational_model.md
@@ -156,8 +156,8 @@ binary from being started directly on a host.
 
 The goal is narrower and more durable:
 
-> **A serious external reconciler should be able to operate Kubidm through supported semantic
-> primitives instead of pretending to be a human system administrator.**
+> **An external reconciler should be able to operate Kubidm through supported semantic primitives
+> instead of pretending to be a human system administrator.**
 
 For the developer-level architectural decision behind this model, see
 [Orchestration Boundary](developers/designs/orchestration_boundary.md).

--- a/book/src/operational_model.md
+++ b/book/src/operational_model.md
@@ -1,0 +1,163 @@
+# Operational Model
+
+Kubidm is designed to work in both simple deployments and orchestrated distributed environments.
+The server does not require Kubernetes, but its operational interfaces are intended to be usable by
+modern reconcilers rather than only by a human following an imperative runbook.
+
+The central model is:
+
+> **Kubidm owns identity and distributed-data correctness. The deployment control plane owns
+> infrastructure policy and reconciliation.**
+
+This separation keeps the server portable while allowing Kubernetes and other orchestration systems
+to manage Kubidm without duplicating its replication or database semantics.
+
+## Simple deployments
+
+A single Kubidm server can be operated as a normal long-running service:
+
+```text
+systemd / container runtime / service supervisor
+                    |
+                    v
+                 kubidmd
+                    |
+                    v
+               local storage
+```
+
+For small deployments this may be all that is required. The administrator chooses when to start,
+stop, upgrade, back up, or maintain the server.
+
+Kubidm continues to support this model. Cloud-native operation does not mean that every installation
+must run Kubernetes.
+
+## Orchestrated distributed deployments
+
+Once a deployment has multiple replicas, persistent storage, replacement workflows, upgrades,
+maintenance, and failure-domain requirements, there are two distinct control problems:
+
+1. **application correctness** — whether a replication, recovery, or database transition is valid;
+2. **infrastructure orchestration** — which instance should change, when it should change, and how
+   the surrounding resources should converge afterward.
+
+Kubidm is authoritative for the first. An external control plane is authoritative for the second.
+
+A Kubernetes deployment therefore looks conceptually like:
+
+```text
+                 Kubernetes API
+                      |
+               desired state
+                      |
+                      v
+                   operator
+             policy + reconciliation
+                      |
+           Kubidm semantic operations
+                      |
+          +-----------+-----------+
+          |                       |
+          v                       v
+       kubidmd A <--- replication ---> kubidmd B
+          |                       |
+          v                       v
+       storage A               storage B
+```
+
+The operator does not become the replication engine. It uses server-provided state and operations to
+sequence cluster workflows while Kubernetes provides scheduling, workload lifecycle, storage
+attachment, desired state, and reconciliation.
+
+## What Kubidm should expose
+
+An orchestrator should not need to parse logs, scrape human-oriented CLI output, sleep for an
+assumed convergence interval, or reproduce Kubidm's database rules.
+
+Where a cluster workflow depends on a Kubidm-specific invariant, Kubidm should expose that invariant
+through a machine-oriented interface. Depending on the operation this can include:
+
+- replication-aware health and state;
+- replication generation identity;
+- drain and resume semantics;
+- replication fences and fence satisfaction;
+- explicit synchronisation or refresh outcomes;
+- recovery state and preconditions;
+- maintenance capabilities and idempotent operations.
+
+The transport may evolve. The important contract is semantic: the server is the component that can
+prove whether the requested data-plane transition is safe.
+
+## What the external control plane should own
+
+The orchestration layer owns questions that are generic to operating workloads rather than to the
+identity database itself, including:
+
+- desired replica count;
+- node and failure-domain placement;
+- persistent-volume lifecycle;
+- workload replacement after infrastructure failure;
+- rollout and upgrade ordering;
+- selection of a replica for maintenance;
+- persistence of long-running workflow progress;
+- retries and reconciliation after controller restart;
+- cluster-level status presented to operators.
+
+In Kubernetes these concerns naturally map to controllers, Custom Resources, StatefulSets, Services,
+CSI-backed storage, topology constraints, status conditions, finalizers, and events.
+
+## Safety over apparent automation
+
+A distributed control plane can make an unsafe workflow look automated. Kubidm deliberately avoids
+that trade.
+
+For example, none of these alone prove that a replica can be removed safely:
+
+```text
+Pod Ready == true
+last replication timestamp is recent
+no errors appeared in logs
+we waited N seconds
+StatefulSet rollout completed
+```
+
+Those may be useful operational signals, but they do not express the replication invariant that the
+workflow actually depends on.
+
+When Kubidm can provide a semantic proof or state transition, automation should use it. When it
+cannot, an orchestrator should prefer a conservative workflow—possibly including temporary service
+downtime—over an optimistic heuristic.
+
+## Reconciler-friendly operations
+
+Modern controllers are not one-shot scripts. They can restart between any two steps and may repeat
+a request after losing the response.
+
+Operator-facing Kubidm operations should therefore be designed so that:
+
+- requests are idempotent or use caller-provided operation identities;
+- current state and progress are machine-readable;
+- capabilities and protocol versions can be discovered;
+- invalid generation/history combinations fail explicitly;
+- failures do not silently return a node to service when safety is unknown;
+- a caller can resume reconciliation without reconstructing hidden server state from logs.
+
+These properties are useful outside Kubernetes too. Ansible, Nomad, VM-management systems, or a
+purpose-built controller can consume the same primitives.
+
+## Kubernetes is an orchestration target, not a server dependency
+
+Kubidm has a strong Kubernetes focus because Kubernetes already supplies a mature generic control
+plane for stateful workloads. Reusing that control plane avoids rebuilding scheduling, desired
+state, leader election, resource lifecycle, storage integration, and reconciliation inside Kubidm.
+
+That does not require importing Kubernetes libraries into `kubidmd`, nor does it prevent a Kubidm
+binary from being started directly on a host.
+
+The goal is narrower and more durable:
+
+> **A serious external reconciler should be able to operate Kubidm through supported semantic
+> primitives instead of pretending to be a human system administrator.**
+
+For the developer-level architectural decision behind this model, see
+[Orchestration Boundary](developers/designs/orchestration_boundary.md).

--- a/book/src/support.md
+++ b/book/src/support.md
@@ -137,6 +137,27 @@ not limited to:
   [`proto/src/internal.rs`](https://github.com/kubidm/kubidm/blob/master/proto/src/internal.rs)
 - SCIM operations from [`proto/src/scim_v1`](https://github.com/kubidm/kubidm/blob/master/proto/src/scim_v1)
 
+#### Operator-facing control interfaces
+
+Kubidm's operational architecture is intended to support external reconcilers. Existing internal and Unix-admin
+interfaces remain subject to the stability rules above unless explicitly documented otherwise; their presence alone does
+not make them a stable operator API.
+
+When an operator-facing control protocol is declared for external use, it should provide the compatibility properties
+needed by a reconciler rather than relying on release-string assumptions or human-oriented output. In particular,
+operator-facing capabilities should be versioned or discoverable, mutating operations should be idempotent or carry a
+stable operation identity, and progress/failure state should be machine-readable.
+
+External automation should depend on documented semantic interfaces. It should not treat log messages, CLI text,
+process state, or timing as stable proofs of database or replication correctness.
+
+Until a particular operator-facing interface is explicitly declared stable, controllers must perform capability/version
+negotiation and should retain a conservative fallback or refuse an operation when the required semantic primitive is not
+available.
+
+See the [Operational Model](operational_model.md) and
+[Orchestration Boundary](developers/designs/orchestration_boundary.md) for the architectural rationale.
+
 ### Deprecation Policy
 
 Features or APIs may be removed with 1 release versions notice. Deprecations will be announced in


### PR DESCRIPTION
## Summary

Make Kubidm's distributed-operations direction explicit and resolve the current documentation conflict between the inherited Replication Coordinator design and the newer node-local maintenance/control-plane architecture.

This PR:

- adds an accepted **Orchestration Boundary** design decision;
- adds a user-facing **Operational Model** explaining simple and orchestrated deployments;
- marks the old **Replication Coordinator** design as **Superseded** while retaining it as architectural history;
- moves the coordinator document into a historical/superseded section of the book navigation;
- updates the README so modern distributed operations and external reconciliation are first-class fork motivations;
- clarifies that Kubernetes is a primary orchestration environment, not a `kubidmd` runtime dependency;
- adds operator-facing API expectations to the support policy without declaring the existing Unix admin interface stable;
- connects the project introduction to the new operational model.

## Motivation

Kubidm already has two materially different operational directions represented in its documentation.

The inherited Replication Coordinator design proposes a Kubidm-managed control plane for registration, membership, topology distribution, generation tracking, certificate updates, and inactive-node cleanup.

Newer work has deliberately moved in another direction: replication-aware readiness, recovery generations, drain/fence semantics, synchronisation barriers, and maintenance operations expose **Kubidm-specific correctness primitives**, while an external orchestrator chooses nodes, sequences operations, persists workflow progress, and reconciles infrastructure.

The newer direction is a cleaner responsibility boundary, but until now it was implicit in individual feature designs. Leaving the KRC document active makes the project architecture ambiguous and risks future work rebuilding generic orchestration inside the identity server.

## Architectural decision

The central principle introduced by this PR is:

> **Kubidm provides the distributed-system mechanisms and proofs; the deployment control plane provides policy and reconciliation.**

### Kubidm owns

- identity and authorization semantics;
- database/on-disk invariants;
- replication protocol and conflict semantics;
- replication generations and history validity;
- drain, fences, fence satisfaction, refresh/recovery safety;
- node-local maintenance and write-admission safety;
- machine-readable semantic state;
- idempotent node-local control operations.

### External orchestration owns

- desired replica count and topology policy;
- scheduling and failure-domain placement;
- workload/storage lifecycle;
- replacement and rollout sequencing;
- selecting peers or maintenance targets;
- persistence of multi-step workflow state;
- retry/replay and convergence after controller restart;
- cluster-level user-facing conditions.

## Why this is not "Kubernetes as a hard dependency"

This PR explicitly preserves simple deployment models. A Kubidm server can still be run directly under systemd, a container runtime, or another supervisor.

The design requirement is instead that advanced automation can consume supported, machine-oriented Kubidm semantics rather than emulate a human administrator through config rewrites, log parsing, CLI text, sleeps, or replicated-state logic outside the server.

Kubernetes is highlighted because it already supplies a mature generic desired-state control plane—watch/reconcile semantics, leader election, scheduling, StatefulSets, CSI, conditions, events, and finalizers—but the server primitives remain deployment-environment independent.

## Replication Coordinator

The KRC document is deliberately **not deleted**. It is retained because it correctly identifies real operational problems: static topology, manual certificate exchange, difficult replica lifecycle, and administrator-driven replication configuration.

What changes is the chosen solution boundary. Instead of adding another cluster-level coordinator inside Kubidm, those requirements should drive small semantic server primitives that an existing external reconciler can compose.

## Operator-facing API policy

The support documentation now distinguishes between today's unstable internal/admin interfaces and the intended properties of future external control protocols.

This PR does **not** promote the current Unix admin socket to a stable API. It states that when operator-facing interfaces are exposed for external use, they should be:

- versioned or capability-discoverable;
- idempotent or operation-ID based;
- machine-readable in progress and failure state;
- safe for retry/replay by reconcilers;
- semantic, rather than dependent on logs, CLI output, timing, or release-string assumptions.

## Scope and non-goals

This is a documentation-only architecture PR. It does not:

- add Kubernetes libraries or a Kubernetes runtime dependency to Kubidm;
- implement a controller or operator;
- change replication behavior, supported topology size, or runtime APIs;
- declare unstable internal APIs stable;
- move replication correctness into an external controller;
- criticize or redefine upstream Kanidm's architecture;
- require every Kubidm user to deploy an orchestrator.

## Validation

- Book navigation includes the new Operational Model and Orchestration Boundary.
- The KRC design is clearly marked Superseded and retained under historical designs.
- README, introduction, support policy, and design documents use the same mechanism-vs-policy boundary.
- No runtime code or generated artifacts are changed.
